### PR TITLE
Add audit hooks

### DIFF
--- a/learn_dbt/dbt_project.yml
+++ b/learn_dbt/dbt_project.yml
@@ -23,6 +23,8 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+on-run-start:
+  - "CREATE TABLE IF NOT EXISTS audit (model TEXT, state TEXT, time timestamp_ltz)"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/learn_dbt/dbt_project.yml
+++ b/learn_dbt/dbt_project.yml
@@ -37,3 +37,4 @@ models:
     # Config indicated by + and applies to all files under models/example/
     example:
       +materialized: view
+      pre-hook: "INSERT INTO dbt.audit (model, state, time) values ('{{this.name}}', 'model_build_start', current_timestamp)"


### PR DESCRIPTION
Example of creating an audit table before running dbt.
Table is filled using pre-hook which logs an entry just before a model starts building.